### PR TITLE
Close #11. Raise exceptions on non-2xx responses for webhooks

### DIFF
--- a/simpl/games/apps.py
+++ b/simpl/games/apps.py
@@ -10,6 +10,8 @@ class SimplGamesConfig(AppConfig):
     name = 'simpl.games'
 
     def ready(self):
+        from .listeners import handle_task_failure  # noqa pylint: disable=unused-variable
+
         webhook_model(get_user_model(),
             on_change=events.on_user_changed,
             on_create=events.on_user_created,

--- a/simpl/games/events.py
+++ b/simpl/games/events.py
@@ -1,57 +1,64 @@
 from thorn import ModelEvent
 
+from .thorn import thorn_app
+
+
+class SimplEvent(ModelEvent):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, app=thorn_app)
+
 
 # Decision events
-on_decision_changed = ModelEvent('{.game.slug}.decision.changed')
-on_decision_created = ModelEvent('{.game.slug}.decision.created')
-on_decision_deleted = ModelEvent('{.game.slug}.decision.deleted')
+on_decision_changed = SimplEvent('{.game.slug}.decision.changed')
+on_decision_created = SimplEvent('{.game.slug}.decision.created')
+on_decision_deleted = SimplEvent('{.game.slug}.decision.deleted')
 
 # Game events
-on_game_changed = ModelEvent('{.slug}.game.changed')
-on_game_created = ModelEvent('{.slug}.game.created')
-on_game_deleted = ModelEvent('{.slug}.game.deleted')
+on_game_changed = SimplEvent('{.slug}.game.changed')
+on_game_created = SimplEvent('{.slug}.game.created')
+on_game_deleted = SimplEvent('{.slug}.game.deleted')
 
 # Period events
-on_period_changed = ModelEvent('{.game.slug}.period.changed')
-on_period_created = ModelEvent('{.game.slug}.period.created')
-on_period_deleted = ModelEvent('{.game.slug}.period.deleted')
+on_period_changed = SimplEvent('{.game.slug}.period.changed')
+on_period_created = SimplEvent('{.game.slug}.period.created')
+on_period_deleted = SimplEvent('{.game.slug}.period.deleted')
 
 # Phase events
-on_phase_changed = ModelEvent('{.game.slug}.phase.changed')
-on_phase_created = ModelEvent('{.game.slug}.phase.created')
-on_phase_deleted = ModelEvent('{.game.slug}.phase.deleted')
+on_phase_changed = SimplEvent('{.game.slug}.phase.changed')
+on_phase_created = SimplEvent('{.game.slug}.phase.created')
+on_phase_deleted = SimplEvent('{.game.slug}.phase.deleted')
 
 # Result events
-on_result_changed = ModelEvent('{.game.slug}.result.changed')
-on_result_created = ModelEvent('{.game.slug}.result.created')
-on_result_deleted = ModelEvent('{.game.slug}.result.deleted')
+on_result_changed = SimplEvent('{.game.slug}.result.changed')
+on_result_created = SimplEvent('{.game.slug}.result.created')
+on_result_deleted = SimplEvent('{.game.slug}.result.deleted')
 
 # Role events
-on_role_changed = ModelEvent('{.game.slug}.role.changed')
-on_role_created = ModelEvent('{.game.slug}.role.created')
-on_role_deleted = ModelEvent('{.game.slug}.role.deleted')
+on_role_changed = SimplEvent('{.game.slug}.role.changed')
+on_role_created = SimplEvent('{.game.slug}.role.created')
+on_role_deleted = SimplEvent('{.game.slug}.role.deleted')
 
 # Run events
-on_run_changed = ModelEvent('{.game.slug}.run.changed')
-on_run_created = ModelEvent('{.game.slug}.run.created')
-on_run_deleted = ModelEvent('{.game.slug}.run.deleted')
+on_run_changed = SimplEvent('{.game.slug}.run.changed')
+on_run_created = SimplEvent('{.game.slug}.run.created')
+on_run_deleted = SimplEvent('{.game.slug}.run.deleted')
 
 # RunUser events
-on_runuser_changed = ModelEvent('{.game.slug}.runuser.changed')
-on_runuser_created = ModelEvent('{.game.slug}.runuser.created')
-on_runuser_deleted = ModelEvent('{.game.slug}.runuser.deleted')
+on_runuser_changed = SimplEvent('{.game.slug}.runuser.changed')
+on_runuser_created = SimplEvent('{.game.slug}.runuser.created')
+on_runuser_deleted = SimplEvent('{.game.slug}.runuser.deleted')
 
 # Scenario events
-on_scenario_changed = ModelEvent('{.game.slug}.scenario.changed')
-on_scenario_created = ModelEvent('{.game.slug}.scenario.created')
-on_scenario_deleted = ModelEvent('{.game.slug}.scenario.deleted')
+on_scenario_changed = SimplEvent('{.game.slug}.scenario.changed')
+on_scenario_created = SimplEvent('{.game.slug}.scenario.created')
+on_scenario_deleted = SimplEvent('{.game.slug}.scenario.deleted')
 
 # World events
-on_world_changed = ModelEvent('{.game.slug}.world.changed')
-on_world_created = ModelEvent('{.game.slug}.world.created')
-on_world_deleted = ModelEvent('{.game.slug}.world.deleted')
+on_world_changed = SimplEvent('{.game.slug}.world.changed')
+on_world_created = SimplEvent('{.game.slug}.world.created')
+on_world_deleted = SimplEvent('{.game.slug}.world.deleted')
 
 # User events
-on_user_changed = ModelEvent('user.changed')
-on_user_created = ModelEvent('user.created')
-on_user_deleted = ModelEvent('user.deleted')
+on_user_changed = SimplEvent('user.changed')
+on_user_created = SimplEvent('user.created')
+on_user_deleted = SimplEvent('user.deleted')

--- a/simpl/games/listeners.py
+++ b/simpl/games/listeners.py
@@ -1,0 +1,9 @@
+import rollbar
+
+from celery.signals import task_failure
+
+
+@task_failure.connect
+def handle_task_failure(**kw):
+    rollbar.report_exc_info(extra_data=kw)
+

--- a/simpl/games/thorn.py
+++ b/simpl/games/thorn.py
@@ -1,0 +1,19 @@
+import requests
+
+from thorn.request import Request as BaseRequest
+from thorn.app import Thorn
+
+
+class Request(BaseRequest):
+    def dispatch(self, session=None, propagate=False):
+        # type: (requests.Session, bool) -> 'Request'
+        super().dispatch(session, propagate)
+        self.response.raise_for_status()
+        return self
+
+
+class App(Thorn):
+    request_cls = 'simpl.games.thorn:Request'
+
+
+thorn_app = App(set_as_current=True)


### PR DESCRIPTION
This will make `thorn` raise an exception on status codes that are `4xx` or `5xx`, which will make the celery task fail.

We also listen to task failures and push them to rollbar.

Note that the task will fail but it won't be retried. The assumption is that if the server replies but the status code is wrong, it's not a network issue and retrying won't be successful. But at least we can track the failure.

I'd like to test this in a dev environment. To test it, we can change one of the subscribers in the admin to use something else than `/callback` (eg `/dummy`) and modifying an object. That would result in a 404 that should hopefully be tracked.